### PR TITLE
Allow folder switching and opening a custom folder

### DIFF
--- a/Piktosaur/App.xaml.cs
+++ b/Piktosaur/App.xaml.cs
@@ -15,6 +15,7 @@ using Windows.ApplicationModel;
 using Windows.ApplicationModel.Activation;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using WinRT.Interop;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -26,6 +27,10 @@ namespace Piktosaur
     /// </summary>
     public partial class App : Application
     {
+        public static Window MainWindow {  get; private set; }
+
+        public static IntPtr MainWindowHandle => WindowNative.GetWindowHandle(MainWindow);
+
         private Window? _window;
 
         /// <summary>
@@ -44,6 +49,8 @@ namespace Piktosaur
         protected override void OnLaunched(Microsoft.UI.Xaml.LaunchActivatedEventArgs args)
         {
             _window = new MainWindow();
+            MainWindow = _window;
+
             _window.ExtendsContentIntoTitleBar = true;
 
             // Cast to MainWindow to access the TitleBar property

--- a/Piktosaur/MainWindow.xaml.cs
+++ b/Piktosaur/MainWindow.xaml.cs
@@ -35,11 +35,23 @@ namespace Piktosaur
             InitializeComponent();
 
             LoadImages();
+
+            AppStateVM.Shared.PropertyChanged += Shared_PropertyChanged;
+        }
+
+        private void Shared_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppStateVM.Shared.SelectedQuery))
+            {
+                LoadImages();
+            }
         }
 
         private async void LoadImages()
         {
-            var result = Search.GetImages(Search.GetPicturesFolder());
+            MainContainer.Children.Clear();
+            var currentQuery = AppStateVM.Shared.SelectedQuery;
+            var result = Search.GetImages(currentQuery.Folders[0]);
             var images = result.Results;
             List<Task> thumbnailTasks = [];
             // pre-generate first 15 image thumbnails

--- a/Piktosaur/ViewModels/AppStateVM.cs
+++ b/Piktosaur/ViewModels/AppStateVM.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using Piktosaur.Models;
 using Piktosaur.Services;
+using Windows.Storage;
 
 namespace Piktosaur.ViewModels
 {
@@ -55,6 +56,14 @@ namespace Piktosaur.ViewModels
             }
 
             return false;
+        }
+
+        public void AddFolderQuery(StorageFolder folder)
+        {
+            var newQuery = new Query(folder.Name, [folder.Path]);
+            Queries.Add(newQuery);
+
+            SelectQuery(newQuery);
         }
     }
 }

--- a/Piktosaur/Views/TitleBar.xaml.cs
+++ b/Piktosaur/Views/TitleBar.xaml.cs
@@ -12,8 +12,12 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using WinRT.Interop;
+using Windows.Storage.Pickers;
+using Windows.Storage;
 
 using Piktosaur.ViewModels;
+using Piktosaur.Models;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -39,6 +43,26 @@ namespace Piktosaur.Views
                 flyoutItem.Click += (sender, e) => ViewModel.SelectQuery(savedQuery);
 
                 MenuElement.Items.Add(flyoutItem);
+            }
+
+            var openFolderFlyoutItem = new MenuFlyoutItem { Text = "Open folder" };
+            openFolderFlyoutItem.Click += (sender, e) => HandleOpenFolderClick();
+
+            MenuElement.Items.Add(openFolderFlyoutItem);
+        }
+
+        private async void HandleOpenFolderClick()
+        {
+            var folderPicker = new FolderPicker();
+            InitializeWithWindow.Initialize(folderPicker, App.MainWindowHandle);
+
+            folderPicker.SuggestedStartLocation = PickerLocationId.Desktop;
+            folderPicker.FileTypeFilter.Add("*");
+
+            StorageFolder folder = await folderPicker.PickSingleFolderAsync();
+            if (folder != null)
+            {
+                AppStateVM.Shared.AddFolderQuery(folder);
             }
         }
     }


### PR DESCRIPTION
## Description

Allow folder switching from the title bar. This both changes the value there, and re-renders the main folder content (and pre-selects the first image, although does not handle the case with no images).

Also introduce the "open folder" option in the dropdown menu to select a custom folder.