### PR TITLE
Switch to the <GridView> component

### DIFF
--- a/Piktosaur/MainWindow.xaml
+++ b/Piktosaur/MainWindow.xaml
@@ -24,9 +24,7 @@
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
         <views:TitleBar x:Name="CustomTitleBar" Grid.Row="0" Grid.ColumnSpan="2"/>
-        <ScrollViewer Grid.Row="1"  x:Name="MainScrollViewer">
-            <StackPanel x:Name="MainContainer" Orientation="Vertical"/>
-        </ScrollViewer>
+        <views:ImageList Grid.Row="1" />
         <views:ImagePreview Grid.Row="1" Grid.Column="1" />
     </Grid>
 </Window>

--- a/Piktosaur/MainWindow.xaml.cs
+++ b/Piktosaur/MainWindow.xaml.cs
@@ -33,58 +33,6 @@ namespace Piktosaur
         public MainWindow()
         {
             InitializeComponent();
-
-            LoadImages();
-
-            AppStateVM.Shared.PropertyChanged += Shared_PropertyChanged;
-        }
-
-        private void Shared_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
-        {
-            if (e.PropertyName == nameof(AppStateVM.Shared.SelectedQuery))
-            {
-                LoadImages();
-            }
-        }
-
-        private async void LoadImages()
-        {
-            MainContainer.Children.Clear();
-            var currentQuery = AppStateVM.Shared.SelectedQuery;
-            var result = Search.GetImages(currentQuery.Folders[0]);
-            var images = result.Results;
-            List<Task> thumbnailTasks = [];
-            // pre-generate first 15 image thumbnails
-            foreach (var image in images.Take(15))
-            {
-                thumbnailTasks.Add(image.GenerateThumbnail());
-            }
-
-            if (images.Count > 0)
-            {
-                AppStateVM.Shared.SelectImage(images[0].Path);
-            }
-
-            // 1. Render Progress bar
-
-            var ProgressElement = new ProgressBar {
-                IsIndeterminate=true,
-                ShowError=false,
-                ShowPaused=false
-            };
-
-            ContainerElement.Children.Add(ProgressElement);
-
-            await Task.WhenAll(thumbnailTasks);
-
-            ContainerElement.Children.Remove(ProgressElement);
-
-            foreach (var image in images)
-            {
-                var ImageComponent = new ImageFile(image);
-
-                MainContainer.Children.Add(ImageComponent);
-            }
         }
     }
 }

--- a/Piktosaur/Piktosaur.csproj
+++ b/Piktosaur/Piktosaur.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Views\ImageFile.xaml" />
+    <None Remove="Views\ImageList.xaml" />
     <None Remove="Views\ImagePreview.xaml" />
     <None Remove="Views\TitleBar.xaml" />
   </ItemGroup>
@@ -43,6 +44,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.4188" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250513003" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Views\ImageList.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Page Update="Views\ImagePreview.xaml">

--- a/Piktosaur/Views/ImageFile.xaml
+++ b/Piktosaur/Views/ImageFile.xaml
@@ -9,8 +9,6 @@
     mc:Ignorable="d">
 
     <Grid Margin="4">
-        <Button Background="Transparent" BorderThickness="0" Padding="0" Click="Button_Click">
-            <Image Width="200" Source="{x:Bind Image.Thumbnail}" Margin="8" />
-        </Button>
+        <Image Width="200" Source="{x:Bind Image.Thumbnail, Mode=OneWay}" Margin="8" />
     </Grid>
 </UserControl>

--- a/Piktosaur/Views/ImageFile.xaml.cs
+++ b/Piktosaur/Views/ImageFile.xaml.cs
@@ -23,17 +23,22 @@ namespace Piktosaur.Views
 {
     public sealed partial class ImageFile : UserControl
     {
-        private ImageResult _imageResult;
-        public ImageResult Image { get => _imageResult; }
-        public ImageFile(ImageResult imageResult)
+        public static readonly DependencyProperty ImageProperty =
+            DependencyProperty.Register(
+                nameof(Image),
+                typeof(ImageResult),
+                typeof(ImageFile),
+                new PropertyMetadata(null));
+
+        public ImageResult Image
         {
-            InitializeComponent();
-            _imageResult = imageResult;
+            get => (ImageResult)GetValue(ImageProperty);
+            set => SetValue(ImageProperty, value);
         }
 
-        private void Button_Click(object sender, RoutedEventArgs e)
+        public ImageFile()
         {
-            AppStateVM.Shared.SelectImage(Image.Path);
+            InitializeComponent();
         }
     }
 }

--- a/Piktosaur/Views/ImageList.xaml
+++ b/Piktosaur/Views/ImageList.xaml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="Piktosaur.Views.ImageList"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Piktosaur.Views"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Piktosaur.Models"
+    mc:Ignorable="d">
+
+    <GridView ItemsSource="{x:Bind ImagesByFolder.View, Mode=OneWay}"
+              SelectionChanged="GridView_SelectionChanged"
+              SelectionMode="Single"
+              IsItemClickEnabled="False">
+        <GridView.ItemsPanel>
+            <ItemsPanelTemplate>
+                <!-- Crucial to use this component for virtualization -->
+                <ItemsStackPanel Orientation="Vertical" />
+            </ItemsPanelTemplate>
+        </GridView.ItemsPanel>
+
+        <GridView.GroupStyle>
+            <GroupStyle>
+                <GroupStyle.HeaderTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Name}" />
+                    </DataTemplate>
+                </GroupStyle.HeaderTemplate>
+            </GroupStyle>
+        </GridView.GroupStyle>
+
+        <GridView.ItemTemplate>
+            <DataTemplate x:DataType="models:ImageResult">
+                <local:ImageFile Image="{x:Bind}" />
+            </DataTemplate>
+        </GridView.ItemTemplate>
+    </GridView>
+</UserControl>

--- a/Piktosaur/Views/ImageList.xaml.cs
+++ b/Piktosaur/Views/ImageList.xaml.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Microsoft.UI.Xaml.Shapes;
+using Piktosaur.Models;
+using Piktosaur.Services;
+using Piktosaur.ViewModels;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace Piktosaur.Views
+{
+    public sealed partial class ImageList : UserControl
+    {
+        public CollectionViewSource ImagesByFolder { get; private set; }
+
+        public ImageList()
+        {
+            InitializeComponent();
+
+            ImagesByFolder = new CollectionViewSource
+            {
+                IsSourceGrouped = true,
+                ItemsPath = new PropertyPath("Images")
+            };
+
+            LoadImages();
+
+            AppStateVM.Shared.PropertyChanged += Shared_PropertyChanged;
+        }
+
+        private void Shared_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            if (e.PropertyName == nameof(AppStateVM.Shared.SelectedQuery))
+            {
+                LoadImages();
+            }
+        }
+
+        private async void LoadImages()
+        {
+            var Folders = new List<FolderWithImages>();
+            var currentQuery = AppStateVM.Shared.SelectedQuery;
+            var result = Search.GetImages(currentQuery.Folders[0]);
+            var images = result.Results;
+            List<Task> thumbnailTasks = [];
+            // pre-generate first 15 image thumbnails
+            foreach (var image in images.Take(15))
+            {
+                thumbnailTasks.Add(image.GenerateThumbnail());
+            }
+
+            if (images.Count > 0)
+            {
+                AppStateVM.Shared.SelectImage(images[0].Path);
+            }
+
+            await Task.WhenAll(thumbnailTasks);
+
+            var folderName = System.IO.Path.GetFileName(result.DirectoryPath);
+            var folderWithImages = new FolderWithImages(folderName, images);
+
+            Folders.Add(folderWithImages);
+
+            ImagesByFolder.Source = Folders;
+        }
+
+        private void GridView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            var gridView = sender as GridView;
+            var selectedItem = gridView?.SelectedItem as ImageResult;
+
+            if (selectedItem != null)
+            {
+                AppStateVM.Shared.SelectImage(selectedItem.Path);
+            }
+        }
+    }
+
+    public class FolderWithImages
+    {
+        public string Name { get; }
+
+        public ObservableCollection<ImageResult> Images { get; }
+
+        public FolderWithImages(string name, IReadOnlyList<ImageResult> images)
+        {
+            Name = name;
+            Images = new ObservableCollection<ImageResult>(images);
+        }
+    }
+}

--- a/Piktosaur/Views/ImagePreview.xaml.cs
+++ b/Piktosaur/Views/ImagePreview.xaml.cs
@@ -28,8 +28,16 @@ public sealed partial class ImagePreview : UserControl
     public ImagePreview()
     {
         InitializeComponent();
+        InitializeImage();
 
         AppStateVM.Shared.PropertyChanged += ViewModel_PropertyChanged;
+    }
+
+    private void InitializeImage()
+    {
+        var selectedImagePath = ViewModel.SelectedImagePath;
+
+        if (selectedImagePath != null) AssignImageSource(selectedImagePath);
     }
 
     private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -42,10 +50,15 @@ public sealed partial class ImagePreview : UserControl
             }
             else
             {
-                var bitmap = new BitmapImage();
-                bitmap.UriSource = new Uri(ViewModel.SelectedImagePath);
-                PreviewImage.Source = bitmap;
-            }   
+                AssignImageSource(ViewModel.SelectedImagePath);
+            }
         }
+    }
+
+    private void AssignImageSource(string imagePath)
+    {
+        var bitmap = new BitmapImage();
+        bitmap.UriSource = new Uri(imagePath);
+        PreviewImage.Source = bitmap;
     }
 }


### PR DESCRIPTION
## Description

Switch to the `<GridView>` component for multiple reasons.

First, it allows to have headers. Second, it supports keyboard navigation within multiple groups (folders in our case). It has hooks for content scrolling (for thumbnail virtualization).