### PR TITLE
Switch to rendering thumbnails directly instead of Windows service

### DIFF
--- a/Piktosaur/Views/ImageFile.xaml.cs
+++ b/Piktosaur/Views/ImageFile.xaml.cs
@@ -50,6 +50,7 @@ namespace Piktosaur.Views
 
                 if (control == null || imageResult?.Thumbnail == null) return;
 
+                control.EffectiveViewportChanged -= control.Item_EffectiveViewportChanged;
                 control.ThumbnailImage.Source = imageResult.Thumbnail;
             }
             catch (Exception ex)
@@ -74,10 +75,9 @@ namespace Piktosaur.Views
         {
             if (args.BringIntoViewDistanceX < 100 && args.BringIntoViewDistanceY < 100)
             {
+                sender.EffectiveViewportChanged -= Item_EffectiveViewportChanged;
                 await Image.GenerateThumbnail();
                 RefreshThumbnail();
-
-                sender.EffectiveViewportChanged -= Item_EffectiveViewportChanged;
             }
         }
     }


### PR DESCRIPTION
## Description

Switch to an algorithm to create thumbnails directly. At least on my machine the experience is much smoother.

There are a few artifacts I've spotted in a folder with 1,000+ images, but maybe the algorithm is faulty for some files or something like that. It is still much better, so I'll keep it for now.

Maybe with this approach I can return the virtualization.