### PR TITLE
Cancellation disposal

### DIFF
--- a/Piktosaur/Models/ImageResult.cs
+++ b/Piktosaur/Models/ImageResult.cs
@@ -11,48 +11,36 @@ using Windows.Storage;
 using Windows.Storage.FileProperties;
 
 using Piktosaur.Services;
+using System.Threading;
 
 namespace Piktosaur.Models
 {
-    public class ImageResult
+    public class ImageResult : IDisposable
     {
         public string Path { get; }
 
-        private uint? width;
-        private uint? height;
-
-        public uint? Width => width;
-        public uint? Height => height;
-
-        private bool isGenerating = false;
+        private bool isDisposed = false;
         public BitmapSource? Thumbnail { get; private set; }
 
         public ImageResult(string path)
         {
             Path = path;
-            // very slow, will need to be offloaded to another thread
-            // CalculateDimensions(path);
         }
 
-        private async void CalculateDimensions(string path)
+        public async Task GenerateThumbnail(CancellationToken cancellationToken)
         {
-            try
-            {
-                var file = await StorageFile.GetFileFromPathAsync(Path);
-                var properties = await file.Properties.GetImagePropertiesAsync();
-                width = properties.Width;
-                height = properties.Height;
-            } catch
-            {
-                // pass
-            }
-        }
-
-        public async Task GenerateThumbnail()
-        {
-            if (Thumbnail != null) return;
-            var thumbnail = await ThumbnailGeneration.Shared.GenerateThumbnail(Path);
+            if (Thumbnail != null || isDisposed || cancellationToken.IsCancellationRequested) return;
+            var thumbnail = await ThumbnailGeneration.Shared.GenerateThumbnail(Path, cancellationToken);
+            if (isDisposed || cancellationToken.IsCancellationRequested) return;
             Thumbnail = thumbnail;
+        }
+
+        public void Dispose()
+        {
+            if (isDisposed) return;
+
+            isDisposed = true;
+            Thumbnail = null;
         }
     }
 }

--- a/Piktosaur/Services/ThumbnailGeneration.cs
+++ b/Piktosaur/Services/ThumbnailGeneration.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Runtime.InteropServices;
@@ -177,13 +178,10 @@ namespace Piktosaur.Services
             {
                 var (thumbnailData, ratio) = await Task.Run(async () =>
                 {
-                    var file = await StorageFile.GetFileFromPathAsync(path);
-                    var properties = await file.Properties.GetImagePropertiesAsync();
-                    double ratio = (double)properties.Width / properties.Height;
-
-                    using var stream = await file.OpenReadAsync();
-
-                    var decoder = await BitmapDecoder.CreateAsync(stream);
+                    using var fileStream = System.IO.File.OpenRead(path);
+                    using var randomAccessStream = fileStream.AsRandomAccessStream();
+                    var decoder = await BitmapDecoder.CreateAsync(randomAccessStream);
+                    double ratio = (double)decoder.PixelWidth / decoder.PixelHeight;
 
                     var transform = new BitmapTransform
                     {

--- a/Piktosaur/ViewModels/AppStateVM.cs
+++ b/Piktosaur/ViewModels/AppStateVM.cs
@@ -65,6 +65,7 @@ namespace Piktosaur.ViewModels
             var newQuery = new Query(relativePath, [folder.Path]);
             Queries.Add(newQuery);
 
+            SelectedImagePath = null;
             SelectQuery(newQuery);
         }
     }

--- a/Piktosaur/ViewModels/FolderWithImages.cs
+++ b/Piktosaur/ViewModels/FolderWithImages.cs
@@ -8,9 +8,11 @@ using Piktosaur.Models;
 
 namespace Piktosaur.ViewModels
 {
-    public class FolderWithImages : BaseViewModel
+    public class FolderWithImages : BaseViewModel, IDisposable
     {
         public string Name { get; }
+
+        private bool isDisposed = false;
 
         private readonly IReadOnlyList<ImageResult> _images;
 
@@ -50,6 +52,20 @@ namespace Piktosaur.ViewModels
                 {
                     Images.Add(image);
                 }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (isDisposed) return;
+
+            isDisposed = true;
+
+            Images.Clear();
+
+            foreach (var image in _images)
+            {
+                image?.Dispose();
             }
         }
     }

--- a/Piktosaur/Views/ImageFile.xaml
+++ b/Piktosaur/Views/ImageFile.xaml
@@ -9,6 +9,10 @@
     mc:Ignorable="d">
 
     <Grid Margin="4">
-        <Image Width="200" x:Name="ThumbnailImage" Margin="8" Loaded="ThumbnailImage_Loaded" />
+        <Image Width="200"
+               x:Name="ThumbnailImage"
+               Margin="8"
+               Loaded="ThumbnailImage_Loaded"
+               Unloaded="ThumbnailImage_Unloaded" />
     </Grid>
 </UserControl>

--- a/Piktosaur/Views/ImageList.xaml
+++ b/Piktosaur/Views/ImageList.xaml
@@ -9,6 +9,7 @@
     xmlns:models="using:Piktosaur.Models"
     xmlns:system="using:System"
     xmlns:converters="using:Piktosaur.Converters"
+    Unloaded="UserControl_Unloaded"
     mc:Ignorable="d">
 
     <UserControl.Resources>

--- a/Piktosaur/Views/TitleBar.xaml.cs
+++ b/Piktosaur/Views/TitleBar.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -10,14 +11,13 @@ using Microsoft.UI.Xaml.Data;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
+using Piktosaur.Models;
+using Piktosaur.ViewModels;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
-using WinRT.Interop;
-using Windows.Storage.Pickers;
 using Windows.Storage;
-
-using Piktosaur.ViewModels;
-using Piktosaur.Models;
+using Windows.Storage.Pickers;
+using WinRT.Interop;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -32,10 +32,18 @@ namespace Piktosaur.Views
             InitializeComponent();
 
             SetFlyoutItems();
+
+            ViewModel.Queries.CollectionChanged += OnQueriesCollectionChanged;
+        }
+
+        private void OnQueriesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            SetFlyoutItems();
         }
 
         private void SetFlyoutItems()
         {
+            MenuElement.Items.Clear();
             foreach (var query in ViewModel.Queries)
             {
                 var savedQuery = query;


### PR DESCRIPTION
## Description

Add proper cleanup:

- each thumbnail generation receives a cancellation token
- when the components are unloaded, they cancel in progress generation
- when the image list is unloaded, all thumbnails are disposed

So it should be safe to both switch the directories mid calculation and no errors on closing the app, as there should be no unsafe memory access.

Also, I switched from WinRT API for file access for regular `System.IO.File` API -- it is much less capable, but for the bulk generation additional properties from WinRT are unnecessary (like EXIF information).