### PR TITLE
Implement priority queue with backpressure

### DIFF
--- a/Piktosaur/Models/ImageResult.cs
+++ b/Piktosaur/Models/ImageResult.cs
@@ -27,12 +27,15 @@ namespace Piktosaur.Models
             Path = path;
         }
 
-        public async Task GenerateThumbnail(CancellationToken cancellationToken)
+        public async Task<Boolean> GenerateThumbnail(CancellationToken cancellationToken)
         {
-            if (Thumbnail != null || isDisposed || cancellationToken.IsCancellationRequested) return;
+            if (Thumbnail != null || isDisposed || cancellationToken.IsCancellationRequested) return false;
             var thumbnail = await ThumbnailGeneration.Shared.GenerateThumbnail(Path, cancellationToken);
-            if (isDisposed || cancellationToken.IsCancellationRequested) return;
+            cancellationToken.ThrowIfCancellationRequested();
+            if (isDisposed) return false;
             Thumbnail = thumbnail;
+
+            return true;
         }
 
         public void Dispose()

--- a/Piktosaur/Services/ThumbnailGeneration.cs
+++ b/Piktosaur/Services/ThumbnailGeneration.cs
@@ -11,8 +11,11 @@ using System.Runtime.InteropServices.WindowsRuntime;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Piktosaur.Utils;
+using Windows.Devices.Radios;
 using Windows.Graphics.Imaging;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
@@ -29,26 +32,28 @@ namespace Piktosaur.Services
         private readonly SemaphoreSlim osThumbnailSemaphore;
         private readonly SemaphoreSlim fallbackThumbnailSemaphore;
 
+        private readonly SmartQueue smartQueue;
+
         private readonly Dictionary<string, Boolean> thumbnailsGenerating = [];
 
         public ThumbnailGeneration()
         {
             osThumbnailSemaphore = new SemaphoreSlim(1, 1);
-            fallbackThumbnailSemaphore = new SemaphoreSlim(Environment.ProcessorCount, Environment.ProcessorCount);
+            fallbackThumbnailSemaphore = new SemaphoreSlim(1, 1);
+
+            smartQueue = new SmartQueue(this);
         }
 
         public async Task<BitmapSource?> GenerateThumbnail(string path, CancellationToken cancellationToken)
         {
             if (thumbnailsGenerating.ContainsKey(path)) return null;
 
-            await osThumbnailSemaphore.WaitAsync(cancellationToken);
-
             try
             {
                 if (thumbnailsGenerating.ContainsKey(path)) return null;
                 thumbnailsGenerating.TryAdd(path, true);
 
-                return await CreateManualThumbnail(path, cancellationToken);
+                return await smartQueue.AddRequest(path, cancellationToken);
             }
             catch (OperationCanceledException)
             {
@@ -56,131 +61,94 @@ namespace Piktosaur.Services
             }
             catch (Exception ex)
             {
+
+                // Log the full exception details including call stack
+                System.Diagnostics.Debug.WriteLine($"Thumbnail generation failed:");
+                System.Diagnostics.Debug.WriteLine($"Exception type: {ex.GetType().FullName}");
+                System.Diagnostics.Debug.WriteLine($"Message: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"Stack trace: {ex.StackTrace}");
+
+                // If it's a COM exception, get the HRESULT
+                if (ex is System.Runtime.InteropServices.COMException comEx)
+                {
+                    System.Diagnostics.Debug.WriteLine($"HRESULT: 0x{comEx.HResult:X8}");
+                }
+
                 Debug.WriteLine($"Error during generating thumbnail: {ex}");
                 return null;
             }
             finally
             {
                 thumbnailsGenerating.Remove(path, out bool _result);
+            }
+        }
+
+        public async Task<BitmapSource> CreateManualThumbnail(string path, CancellationToken cancellationToken)
+        {
+            await osThumbnailSemaphore.WaitAsync(cancellationToken);
+
+            try
+            {
+                var (thumbnailData, ratio) = await GeneratePixelData(path, cancellationToken);
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                await WaitForFrameOpportunity();
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var writeableBitmap = new WriteableBitmap(200, (int)(200 / ratio));
+                using (var pixelStream = writeableBitmap.PixelBuffer.AsStream())
+                {
+                    await pixelStream.WriteAsync(thumbnailData, 0, thumbnailData.Length, cancellationToken);
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                return writeableBitmap;
+            }
+            finally
+            {
                 osThumbnailSemaphore.Release();
             }
         }
 
-        private async Task<BitmapSource?> GenerateOSThumbnail(string path)
+        private async Task WaitForFrameOpportunity()
         {
-            StorageItemThumbnail? thumbnail = await GenerateOSThumbnailWithRetries(path);
+            // wait for one frame
+            await Task.Delay(16);
+            var tcs = new TaskCompletionSource<bool>();
 
-            if (thumbnail == null)
+            void OnRendering(object sender, object e)
             {
-                Debug.WriteLine("Could not generate the bitmap image");
-                return null;
+                CompositionTarget.Rendering -= OnRendering;
+                tcs.SetResult(true);
             }
-            else
-            {
-                Debug.WriteLine("Generating bitmap image");
-                BitmapImage bitmapImage = new BitmapImage();
-                await bitmapImage.SetSourceAsync(thumbnail);
-                thumbnail.Dispose();
 
-                return bitmapImage;
-            }
+            CompositionTarget.Rendering += OnRendering;
+            await tcs.Task;
         }
 
-        private Task<StorageItemThumbnail?> GenerateOSThumbnailWithRetries(string path)
+        private async Task<(byte[], double)> GeneratePixelData(string path, CancellationToken cancellationToken)
         {
-            return GenerateOSThumbnailWithRetries(path, 1, 3);
-        }
-
-        private async Task<StorageItemThumbnail?> GenerateOSThumbnailWithRetries(string path, int currentRetry, int maxRetries)
-        {
-            try
-            {
-                var result = await GenerateOSThumbnailImpl(path);
-
-                if (result != null)
-                {
-                    return result;
-                }
-            }
-            catch (OperationCanceledException) {
-                Debug.WriteLine("Timed out generating a thumbnail using OS");
-                return null;
-            }
-
-            if (currentRetry >= maxRetries) {
-                return null;
-            }
-
-            // to give the thumbnail service a chance to recover
-            await Task.Delay(500);
-
-            return await GenerateOSThumbnailWithRetries(path, currentRetry + 1, maxRetries);
-        }
-
-        private async Task<StorageItemThumbnail?> GenerateOSThumbnailImpl(string path)
-        {
-            try
-            {
-                await Throttler.ThrottleWinRT();
-                StorageFile file = await StorageFile.GetFileFromPathAsync(path);
-
-                var thumbnailTask = file.GetThumbnailAsync(
-                    ThumbnailMode.SingleItem,
-                    200,
-                    ThumbnailOptions.UseCurrentScale
-                ).AsTask();
-                var timeoutTask = Task.Delay(2500);
-
-                var completed = await Task.WhenAny(thumbnailTask, timeoutTask);
-
-                if (completed == timeoutTask)
-                {
-                    Debug.WriteLine("Thumbnail generation timed out");
-                    throw new OperationCanceledException("Thumbnail generation timed out");
-                }
-
-                var thumbnail = await thumbnailTask;
-
-                if (thumbnail != null)
-                {
-                    if (thumbnail.Type == ThumbnailType.Icon)
-                    {
-                        // we are only interested in images;
-                        thumbnail.Dispose();
-                        System.Diagnostics.Debug.WriteLine("Generated an icon instead of image");
-                        return null;
-                    }
-                    return thumbnail;
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                throw; // Re-throw to be caught by caller
-            }
-            catch (COMException ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"Thumbnail failed: {ex.Message}");
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"Unexpected error: {ex.Message}");
-            }
-
-            Debug.WriteLine("Could not get OS Thumbnail");
-            return null;
-        }
-
-        private async Task<BitmapSource> CreateManualThumbnail(string path, CancellationToken cancellationToken)
-        {
-            await fallbackThumbnailSemaphore.WaitAsync(cancellationToken);
+            //await fallbackThumbnailSemaphore.WaitAsync(cancellationToken);
 
             try
             {
-                var (thumbnailData, ratio) = await Task.Run(async () =>
+                return await Task.Run(async () =>
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     using var fileStream = System.IO.File.OpenRead(path);
                     using var randomAccessStream = fileStream.AsRandomAccessStream();
-                    var decoder = await BitmapDecoder.CreateAsync(randomAccessStream);
+
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    var decoder = await BitmapDecoder.CreateAsync(randomAccessStream)
+                        .AsTask(cancellationToken);
+
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     double ratio = (double)decoder.PixelWidth / decoder.PixelHeight;
 
                     var transform = new BitmapTransform
@@ -190,31 +158,111 @@ namespace Piktosaur.Services
                         InterpolationMode = BitmapInterpolationMode.Fant
                     };
 
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     var pixelData = await decoder.GetPixelDataAsync(
                         BitmapPixelFormat.Bgra8,
                         BitmapAlphaMode.Premultiplied,
                         transform,
                         ExifOrientationMode.RespectExifOrientation,
                         ColorManagementMode.DoNotColorManage
-                    );
+                    ).AsTask(cancellationToken);
+
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     return (pixelData.DetachPixelData(), ratio);
-                });
-
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var writeableBitmap = new WriteableBitmap(200, (int)(200 / ratio));
-                using (var pixelStream = writeableBitmap.PixelBuffer.AsStream())
-                {
-                    await pixelStream.WriteAsync(thumbnailData, 0, thumbnailData.Length);
-                }
-
-                return writeableBitmap;
+                }, cancellationToken);
             }
             finally
             {
-                fallbackThumbnailSemaphore.Release();
+                //fallbackThumbnailSemaphore.Release();
             }
+        }
+    }
+
+    public class SmartQueue
+    {
+        private readonly int MAX_REQUESTS = 15;
+        private List<QueueItem> requests = new();
+
+        private ThumbnailGeneration thumbnailGeneration;
+
+        private bool isExecuting = false;
+
+        public SmartQueue(ThumbnailGeneration thumbnailGeneration)
+        {
+            this.thumbnailGeneration = thumbnailGeneration;
+        }
+
+        public Task<BitmapSource?> AddRequest(string path, CancellationToken ct)
+        {
+            TaskCompletionSource<BitmapSource?> tcs = new();
+            if (requests.Count > MAX_REQUESTS)
+            {
+                var oldestRequest = requests.Last();
+                oldestRequest.Tcs.SetResult(null);
+                requests.Remove(oldestRequest);
+            }
+
+            requests.Insert(0, new QueueItem(tcs, path, ct));
+            ExecuteRequests();
+
+            return tcs.Task;
+        }
+
+        public async void ExecuteRequests()
+        {
+            if (isExecuting) return;
+
+            isExecuting = true;
+
+            while (GetNextRequest() is var newRequest && newRequest != null)
+            {
+                // remove the request first from the data structure
+                requests.Remove(newRequest);
+                
+                try
+                {
+                    var result = await thumbnailGeneration.CreateManualThumbnail(newRequest.Path, newRequest.ct);
+                    newRequest.Tcs.SetResult(result);
+                }
+                catch
+                {
+                    newRequest.Tcs.SetResult(null);
+                }
+            }
+
+            isExecuting = false;
+        }
+
+        private QueueItem? GetNextRequest()
+        {
+            if (requests.Count == 0) return null;
+            return requests.Last();
+        }
+
+        public void Clear()
+        {
+            foreach (var request in requests)
+            {
+                request.Tcs.SetResult(null);
+            }
+
+            requests.Clear();
+        }
+    }
+
+    public class QueueItem
+    {
+        public TaskCompletionSource<BitmapSource?> Tcs;
+        public string Path;
+        public CancellationToken ct;
+
+        public QueueItem(TaskCompletionSource<BitmapSource?> tcs, string path, CancellationToken ct)
+        {
+            Tcs = tcs;
+            Path = path;
+            this.ct = ct;
         }
     }
 }

--- a/Piktosaur/ViewModels/FolderWithImages.cs
+++ b/Piktosaur/ViewModels/FolderWithImages.cs
@@ -61,8 +61,6 @@ namespace Piktosaur.ViewModels
 
             isDisposed = true;
 
-            Images.Clear();
-
             foreach (var image in _images)
             {
                 image?.Dispose();

--- a/Piktosaur/Views/ImageFile.xaml
+++ b/Piktosaur/Views/ImageFile.xaml
@@ -6,13 +6,13 @@
     xmlns:local="using:Piktosaur.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Loaded="ThumbnailImage_Loaded"
+    Unloaded="ThumbnailImage_Unloaded"
     mc:Ignorable="d">
 
     <Grid Margin="4">
         <Image Width="200"
                x:Name="ThumbnailImage"
-               Margin="8"
-               Loaded="ThumbnailImage_Loaded"
-               Unloaded="ThumbnailImage_Unloaded" />
+               Margin="8" />
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Description

This PR implements a priority queue with backpressure. We only store 15 thumbnail requests, and if we get more, we start throwing out the oldest. The logic is:

- if we can't handle requests, it means the user is scrolling fast
- once the user stops, we'll stop throwing out requests, and we'll create thumbnails for all relevant pictures

There are some potential improvements, but this already improves the perceived performance dramatically.