### PR TITLE
Dispose queue correctly

### DIFF
--- a/Piktosaur/Models/ImageResult.cs
+++ b/Piktosaur/Models/ImageResult.cs
@@ -22,15 +22,18 @@ namespace Piktosaur.Models
         private bool isDisposed = false;
         public BitmapSource? Thumbnail { get; private set; }
 
-        public ImageResult(string path)
+        private ThumbnailGeneration thumbnailGeneration;
+
+        public ImageResult(string path, ThumbnailGeneration thumbnailGeneration)
         {
             Path = path;
+            this.thumbnailGeneration = thumbnailGeneration;
         }
 
         public async Task<Boolean> GenerateThumbnail(CancellationToken cancellationToken)
         {
             if (Thumbnail != null || isDisposed || cancellationToken.IsCancellationRequested) return false;
-            var thumbnail = await ThumbnailGeneration.Shared.GenerateThumbnail(Path, cancellationToken);
+            var thumbnail = await thumbnailGeneration.GenerateThumbnail(Path, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
             if (isDisposed) return false;
             Thumbnail = thumbnail;

--- a/Piktosaur/Models/SearchResults.cs
+++ b/Piktosaur/Models/SearchResults.cs
@@ -20,9 +20,9 @@ namespace Piktosaur.Models
             Path = path;
         }
 
-        public void AddImage(string path)
+        public void AddImage(string path, ThumbnailGeneration thumbnailGeneration)
         {
-            Images.Add(new ImageResult(path));
+            Images.Add(new ImageResult(path, thumbnailGeneration));
         }
 
         public void AddDirectory(SearchResults directoryResults)

--- a/Piktosaur/Services/Search.cs
+++ b/Piktosaur/Services/Search.cs
@@ -24,9 +24,16 @@ namespace Piktosaur.Services
     /// </summary>
     public class Search
     {
+        private ThumbnailGeneration thumbnailGeneration;
+
         public static string[] ImageExtensions = [".jpg", ".jpeg", ".png"];
 
-        public static ImagesData GetImages(string path)
+        public Search(ThumbnailGeneration thumbnailGeneration)
+        {
+            this.thumbnailGeneration = thumbnailGeneration;
+        }
+
+        public ImagesData GetImages(string path)
         {
             var results = new SearchResults(path);
             ReadDirectory(path, results);
@@ -34,7 +41,7 @@ namespace Piktosaur.Services
             return ConvertSearchResults(results, null);
         }
 
-        private static void ReadDirectory(string path, SearchResults searchResults)
+        private void ReadDirectory(string path, SearchResults searchResults)
         {
             if (!Directory.Exists(path))
             {
@@ -59,7 +66,7 @@ namespace Piktosaur.Services
                         continue; // File is likely in cloud storage
                     }
 
-                    searchResults.AddImage(file);
+                    searchResults.AddImage(file, thumbnailGeneration);
                 }
             }
 

--- a/Piktosaur/Services/ThumbnailGeneration.cs
+++ b/Piktosaur/Services/ThumbnailGeneration.cs
@@ -22,9 +22,9 @@ using Windows.Storage.FileProperties;
 
 namespace Piktosaur.Services
 {
-    public class ThumbnailGeneration
+    public class ThumbnailGeneration : IDisposable
     {
-        public static ThumbnailGeneration Shared = new ThumbnailGeneration();
+        private bool isDisposed = false;
 
         private readonly SemaphoreSlim osThumbnailSemaphore;
 
@@ -79,6 +79,15 @@ namespace Piktosaur.Services
             {
                 osThumbnailSemaphore.Release();
             }
+        }
+
+        public void Dispose()
+        {
+            if (isDisposed) return;
+
+            isDisposed = true;
+
+            smartQueue.Dispose();
         }
     }
 }

--- a/Piktosaur/ViewModels/ImagesListVM.cs
+++ b/Piktosaur/ViewModels/ImagesListVM.cs
@@ -10,9 +10,11 @@ using Piktosaur.Services;
 
 namespace Piktosaur.ViewModels
 {
-    public class ImagesListVM : BaseViewModel
+    public class ImagesListVM : BaseViewModel, IDisposable
     {
         private AppStateVM appStateVM;
+
+        private ThumbnailGeneration thumbnailGeneration;
 
         private List<FolderWithImages> folders = new();
 
@@ -31,12 +33,13 @@ namespace Piktosaur.ViewModels
         public ImagesListVM(AppStateVM appStateVM)
         {
             this.appStateVM = appStateVM;
+            thumbnailGeneration = new ThumbnailGeneration();
         }
 
         public async Task<List<FolderWithImages>> LoadImages()
         {
             var currentQuery = appStateVM.SelectedQuery;
-            var result = Search.GetImages(currentQuery.Folders[0]);
+            var result = new Search(thumbnailGeneration).GetImages(currentQuery.Folders[0]);
             var images = result.Results;
 
             List<Task> thumbnailTasks = [];
@@ -94,13 +97,15 @@ namespace Piktosaur.ViewModels
             }
         }
 
-        public void ClearFoldersData()
+        public void Dispose()
         {
             cancellationTokenSource?.Cancel();
             foreach (var folder in folders)
             {
                 folder?.Dispose();
             }
+
+            thumbnailGeneration.Dispose();
         }
     }
 }

--- a/Piktosaur/Views/ImageList.xaml.cs
+++ b/Piktosaur/Views/ImageList.xaml.cs
@@ -90,7 +90,7 @@ namespace Piktosaur.Views
 
         private void UserControl_Unloaded(object sender, RoutedEventArgs e)
         {
-            VM.ClearFoldersData();
+            VM.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Description

This is a pretty big change, this refactor goes away with static search and makes `ThumbnailGeneration` not a singleton. Basically, every image list will have to create its own version, which will also make sure that they will have their own non-shared queue (e.g. when you switch a folder).

So when the images list is unloaded, everything is disposed. I think conceptually it makes it much easier to follow.