### PR TITLE
Read directories and files in another thread

### DIFF
--- a/Piktosaur/Models/ImageResult.cs
+++ b/Piktosaur/Models/ImageResult.cs
@@ -1,26 +1,35 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Piktosaur.Services;
+using Piktosaur.ViewModels;
 using Windows.Graphics.Imaging;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
 
-using Piktosaur.Services;
-using System.Threading;
-
 namespace Piktosaur.Models
 {
-    public class ImageResult : IDisposable
+    public class ImageResult : BaseViewModel, IDisposable
     {
         public string Path { get; }
 
         private bool isDisposed = false;
-        public BitmapSource? Thumbnail { get; private set; }
+
+        private BitmapSource? _thumbnail;
+
+        public BitmapSource? Thumbnail
+        {
+            get => _thumbnail;
+            private set => SetProperty(ref _thumbnail, value);
+        }
 
         private ThumbnailGeneration thumbnailGeneration;
 

--- a/Piktosaur/Models/SearchResults.cs
+++ b/Piktosaur/Models/SearchResults.cs
@@ -11,8 +11,6 @@ namespace Piktosaur.Models
     {
         public List<ImageResult> Images { get; private set; } = [];
 
-        public List<SearchResults> Directories { get; private set; } = [];
-
         public string Path { get; }
 
         public SearchResults(string path)
@@ -23,11 +21,6 @@ namespace Piktosaur.Models
         public void AddImage(string path, ThumbnailGeneration thumbnailGeneration)
         {
             Images.Add(new ImageResult(path, thumbnailGeneration));
-        }
-
-        public void AddDirectory(SearchResults directoryResults)
-        {
-            Directories.Add(directoryResults);
         }
     }
 }

--- a/Piktosaur/Services/ThumbnailGeneration.cs
+++ b/Piktosaur/Services/ThumbnailGeneration.cs
@@ -50,7 +50,8 @@ namespace Piktosaur.Services
                 if (thumbnailsGenerating.ContainsKey(path)) return null;
                 thumbnailsGenerating.TryAdd(path, true);
 
-                return await smartQueue.AddRequest(path, cancellationToken);
+                var result = await smartQueue.AddRequest(path, cancellationToken);
+                return result;
             }
             catch (OperationCanceledException)
             {

--- a/Piktosaur/ViewModels/FolderWithImages.cs
+++ b/Piktosaur/ViewModels/FolderWithImages.cs
@@ -17,7 +17,7 @@ namespace Piktosaur.ViewModels
 
         private bool isDisposed = false;
 
-        private readonly IReadOnlyList<ImageResult> _images;
+        private readonly List<ImageResult> _images = [];
 
         private bool expanded;
 
@@ -27,14 +27,22 @@ namespace Piktosaur.ViewModels
             private set => SetProperty(ref expanded, value);
         }
 
-        public ObservableCollection<ImageResult> Images { get; }
+        public ObservableCollection<ImageResult> Images { get; } = [];
 
-        public FolderWithImages(string name, IReadOnlyList<ImageResult> images, bool isExpanded = true)
+        public FolderWithImages(string name, bool isExpanded = true)
         {
             Name = name;
-            _images = images;
-            Images = isExpanded ? new ObservableCollection<ImageResult>(images) : new ObservableCollection<ImageResult>();
             expanded = isExpanded;
+        }
+
+        public void AddImage(ImageResult image)
+        {
+            _images.Add(image);
+
+            if (expanded)
+            {
+                Images.Add(image);
+            }
         }
 
         public void ToggleExpanded()

--- a/Piktosaur/Views/ImageFile.xaml
+++ b/Piktosaur/Views/ImageFile.xaml
@@ -13,6 +13,7 @@
     <Grid Margin="4">
         <Image Width="200"
                x:Name="ThumbnailImage"
+               Source="{x:Bind Image.Thumbnail, Mode=OneWay}"
                Margin="8" />
     </Grid>
 </UserControl>

--- a/Piktosaur/Views/ImageFile.xaml.cs
+++ b/Piktosaur/Views/ImageFile.xaml.cs
@@ -22,10 +22,6 @@ using System.Threading;
 
 namespace Piktosaur.Views
 {
-    /// <summary>
-    /// This component handles all updates imperatively and uses no binding to XAML file
-    /// in order to keep flexibility to offload images in the future.
-    /// </summary>
     public sealed partial class ImageFile : UserControl
     {
         public bool _unloaded = false;
@@ -35,7 +31,7 @@ namespace Piktosaur.Views
                 nameof(Image),
                 typeof(ImageResult),
                 typeof(ImageFile),
-                new PropertyMetadata(null, OnImageChanged));
+                new PropertyMetadata(null));
 
         public ImageResult Image
         {
@@ -48,40 +44,6 @@ namespace Piktosaur.Views
         public ImageFile()
         {
             InitializeComponent();
-        }
-
-        private static void OnImageChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-        {
-            try
-            {
-                var control = d as ImageFile;
-                var imageResult = e.NewValue as ImageResult;
-
-                if (control == null || imageResult?.Thumbnail == null) return;
-
-                control.EffectiveViewportChanged -= control.Item_EffectiveViewportChanged;
-                if (control._unloaded == true) return;
-                control.ThumbnailImage.Source = imageResult.Thumbnail;
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine($"OnImageChanged error: {ex}");
-            }
-        }
-
-        private void RefreshThumbnail()
-        {
-            if (_unloaded == true) return;
-            if (cancellationTokenSource != null && cancellationTokenSource.Token.IsCancellationRequested) return;
-            if (Image?.Thumbnail == null)
-            {
-                // if we are here, it means that thumbnail generation didn't succeed
-                // so we need to "reset" the state so it can be fetched again
-                cancellationTokenSource = null;
-                this.EffectiveViewportChanged += Item_EffectiveViewportChanged;
-                return;
-            }
-            ThumbnailImage.Source = Image.Thumbnail;
         }
 
         private void ThumbnailImage_Loaded(object sender, RoutedEventArgs e)
@@ -110,11 +72,6 @@ namespace Piktosaur.Views
                 try
                 {
                     await Image.GenerateThumbnail(cancellationTokenSource.Token);
-
-                    if (!cancellationTokenSource.Token.IsCancellationRequested && !_unloaded)
-                    {
-                        RefreshThumbnail();
-                    }
                 }
                 catch (OperationCanceledException)
                 {

--- a/Piktosaur/Views/ImageList.xaml
+++ b/Piktosaur/Views/ImageList.xaml
@@ -14,8 +14,9 @@
 
     <UserControl.Resources>
         <CollectionViewSource x:Name="ImagesByFolder" 
-                          IsSourceGrouped="True" 
-                          ItemsPath="Images"/>
+                              Source="{x:Bind Folders}"
+                              IsSourceGrouped="True" 
+                              ItemsPath="Images"/>
         <converters:BoolToAngleConverter x:Key="BoolToAngleConverter" />
         <converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
     </UserControl.Resources>

--- a/Piktosaur/Views/ImageList.xaml.cs
+++ b/Piktosaur/Views/ImageList.xaml.cs
@@ -29,12 +29,13 @@ namespace Piktosaur.Views
 {
     public sealed partial class ImageList : UserControl
     {
+        public ObservableCollection<FolderWithImages> Folders { get; } = new();
+
         private readonly ImagesListVM VM = new ImagesListVM(AppStateVM.Shared);
 
         public ImageList()
         {
             InitializeComponent();
-
             LoadImages();
         }
 
@@ -42,8 +43,7 @@ namespace Piktosaur.Views
         {
             try
             {
-                var folders = await VM.LoadImages();
-                ImagesByFolder.Source = folders;
+                await VM.LoadImages(Folders);
 
                 // small delay to guarantee that grid view will be properly focused
                 // and the keyboard navigation will work immediately


### PR DESCRIPTION
## Description

All reads are always sync operations, which in theory can be pretty expensive. To lighten the load somewhat, all directories beyond the first one are pushed onto another thread.