### PR TITLE
Change virtualization to the GridView level back

### DIFF
--- a/Piktosaur/Utils/SmartQueue.cs
+++ b/Piktosaur/Utils/SmartQueue.cs
@@ -23,7 +23,7 @@ namespace Piktosaur.Utils
     /// </summary>
     public class SmartQueue : IDisposable
     {
-        private readonly int MAX_REQUESTS = 15;
+        private readonly int MAX_REQUESTS = 25;
         private List<QueueItem> requests = new();
 
         private ThumbnailGeneration thumbnailGeneration;

--- a/Piktosaur/ViewModels/ImagesListVM.cs
+++ b/Piktosaur/ViewModels/ImagesListVM.cs
@@ -63,7 +63,7 @@ namespace Piktosaur.ViewModels
 
             cancellationTokenSource = new CancellationTokenSource();
 
-            foreach (var image in folder.Images.Take(10))
+            foreach (var image in folder.Images.Take(25))
             {
                 thumbnailTasks.Add(image.GenerateThumbnail(cancellationTokenSource.Token));
             }

--- a/Piktosaur/Views/ImageFile.xaml
+++ b/Piktosaur/Views/ImageFile.xaml
@@ -6,8 +6,6 @@
     xmlns:local="using:Piktosaur.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    Loaded="ThumbnailImage_Loaded"
-    Unloaded="ThumbnailImage_Unloaded"
     mc:Ignorable="d">
 
     <Grid Margin="4">

--- a/Piktosaur/Views/ImageFile.xaml.cs
+++ b/Piktosaur/Views/ImageFile.xaml.cs
@@ -39,57 +39,9 @@ namespace Piktosaur.Views
             set => SetValue(ImageProperty, value);
         }
 
-        private CancellationTokenSource? cancellationTokenSource;
-
         public ImageFile()
         {
             InitializeComponent();
-        }
-
-        private void ThumbnailImage_Loaded(object sender, RoutedEventArgs e)
-        {
-            this.EffectiveViewportChanged += Item_EffectiveViewportChanged;
-        }
-
-        /// <summary>
-        /// This function implements virtualization. When the item is close to be shown,
-        /// it requests creating a custom thumbnail. The actual thumbnail request can be
-        /// denied if there are too many requests coming in (usually in case of rapid scroll).
-        /// </summary>
-        private async void Item_EffectiveViewportChanged(FrameworkElement sender, EffectiveViewportChangedEventArgs args)
-        {
-            if (Image == null) return;
-            if (_unloaded == true || Image.Thumbnail != null)
-            {
-                this.EffectiveViewportChanged -= Item_EffectiveViewportChanged;
-                return;
-            }
-            if (cancellationTokenSource != null) return;
-            if (args.BringIntoViewDistanceX < 100 && args.BringIntoViewDistanceY < 100)
-            {
-                this.EffectiveViewportChanged -= Item_EffectiveViewportChanged;
-                cancellationTokenSource = new CancellationTokenSource();
-                try
-                {
-                    await Image.GenerateThumbnail(cancellationTokenSource.Token);
-                }
-                catch (OperationCanceledException)
-                {
-                    // do nothing
-                }
-                catch
-                {
-                    System.Diagnostics.Debug.WriteLine("Failed to generate thumbnail");
-                }
-            }
-        }
-
-        private void ThumbnailImage_Unloaded(object sender, RoutedEventArgs e)
-        {
-            _unloaded = true;
-            cancellationTokenSource?.Cancel();
-            //cancellationTokenSource?.Dispose();
-            this.EffectiveViewportChanged -= Item_EffectiveViewportChanged;
         }
     }
 }

--- a/Piktosaur/Views/ImageList.xaml
+++ b/Piktosaur/Views/ImageList.xaml
@@ -36,16 +36,15 @@
         <GridView Grid.Row="1"
                   ItemsSource="{Binding Source={StaticResource ImagesByFolder}}"
                   SelectionChanged="GridView_SelectionChanged"
+                  ContainerContentChanging="GridView_ContainerContentChanging"
                   SelectionMode="Single"
                   IsItemClickEnabled="False"
                   x:Name="GridViewElement"
                   Margin="8,0,0,0">
             <GridView.ItemsPanel>
                 <ItemsPanelTemplate>
-                    <!-- Intentionally turning off virtualization -->
-                    <!-- Dynamically creating thumbnails creates weird artifacts -->
-                    <!-- since virtualization reuses components -->
-                    <StackPanel Orientation="Vertical" />
+                    <!-- Crucial to use this component for virtualization -->
+                    <ItemsStackPanel Orientation="Vertical" />
                 </ItemsPanelTemplate>
             </GridView.ItemsPanel>
 


### PR DESCRIPTION
## Description

Change virtualization back to the GridView level.

I switched back and aside from some artifacts it works incredibly well (unless you scroll too fast). I assume it is mostly related to the backpressure implementation.

It is a tad too aggressive, but I think I can implement a back queue and that should make sure we don't drop any requests.