### PR TITLE
Set default thumbnail height to make them square

### DIFF
--- a/Piktosaur/Converters/ThumbnailHeightConverter.cs
+++ b/Piktosaur/Converters/ThumbnailHeightConverter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.UI.Xaml.Data;
+
+namespace Piktosaur.Converters
+{
+    public class ThumbnailHeightConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, string language)
+        {
+            // If thumbnail is not loaded (null), return the default height
+            // It uses square dimensions, which is not perfect (most images are 16:9 today),
+            // but it helps because GridView virtualization is a little bit too aggressive
+            if (value == null)
+            {
+                return 200.0;
+            }
+            // If thumbnail is loaded, return NaN to use auto-sizing
+            return double.NaN;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, string language)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Piktosaur/Utils/SmartQueue.cs
+++ b/Piktosaur/Utils/SmartQueue.cs
@@ -23,7 +23,7 @@ namespace Piktosaur.Utils
     /// </summary>
     public class SmartQueue : IDisposable
     {
-        private readonly int MAX_REQUESTS = 25;
+        private readonly int MAX_REQUESTS = 20;
         private List<QueueItem> requests = new();
 
         private ThumbnailGeneration thumbnailGeneration;

--- a/Piktosaur/Views/ImageFile.xaml
+++ b/Piktosaur/Views/ImageFile.xaml
@@ -6,12 +6,18 @@
     xmlns:local="using:Piktosaur.Views"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:converters="using:Piktosaur.Converters"
     mc:Ignorable="d">
+
+    <UserControl.Resources>
+        <converters:ThumbnailHeightConverter x:Key="ThumbnailHeightConverter" />
+    </UserControl.Resources>
 
     <Grid Margin="4">
         <Image Width="200"
                x:Name="ThumbnailImage"
                Source="{x:Bind Image.Thumbnail, Mode=OneWay}"
+               Height="{x:Bind Image.Thumbnail, Mode=OneWay, Converter={StaticResource ThumbnailHeightConverter}}"
                Margin="8" />
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Description

Set default thumbnail height to make them square. This makes aggressive callback `ContainerContentChanging` to chill a bit, so mostly images preload correctly.

I think I can add a "priority" thumbnail request to the one we are hovering over (maybe a priority queue), but this seems to be working pretty well even now