### PR TITLE
More robust reading of folders

### DIFF
--- a/Piktosaur/Services/ThumbnailGeneration.cs
+++ b/Piktosaur/Services/ThumbnailGeneration.cs
@@ -26,18 +26,12 @@ namespace Piktosaur.Services
     {
         private bool isDisposed = false;
 
-        private readonly SemaphoreSlim osThumbnailSemaphore;
-
         private readonly SmartQueue smartQueue;
 
         private readonly Dictionary<string, Boolean> thumbnailsGenerating = [];
 
         public ThumbnailGeneration()
         {
-            // the original idea was to enable multiple threads, but from my testing
-            // single threading model has the best UI performance
-            osThumbnailSemaphore = new SemaphoreSlim(4, 4);
-
             smartQueue = new SmartQueue(this);
         }
 

--- a/Piktosaur/ViewModels/ImagesListVM.cs
+++ b/Piktosaur/ViewModels/ImagesListVM.cs
@@ -46,6 +46,10 @@ namespace Piktosaur.ViewModels
             var currentQuery = appStateVM.SelectedQuery;
             new Search(thumbnailGeneration, folders).GetImages(currentQuery.Folders[0]);
 
+            // give it 100ms to load the first folder. This is not guaranteed by any means
+            // but should work most of the time
+            await Task.Delay(100);
+
             await LoadThumbnails(folders);
 
             Loading = false;


### PR DESCRIPTION
## Description

Implement more robust reading of folders -- handle exceptions (by swallowing them silently for now) of both folders and files, use `EnumerateFiles` instead of `ReadFiles` as that should be more performant (it loads them lazily compared to loading them fully in memory).

Also reading everything happens in 1 background thread, not 1 thread per background folder.